### PR TITLE
Added redirect to VMI_SIGNUP_URL

### DIFF
--- a/sharemyhealth/settings.py
+++ b/sharemyhealth/settings.py
@@ -251,7 +251,7 @@ DISCLOSURE_TEXT = env('DJANGO_PRIVACY_POLICY_URI', DEFAULT_DISCLOSURE_TEXT)
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://sharemyhealth:8000')
 
-VMI_SIGNUP_URL = "%s/accounts/create-account/%s/?redirect_url=%s" % \
+VMI_SIGNUP_URL = "%s/accounts/create-account/%s/?next=%s" % \
                  (SOCIAL_AUTH_VERIFYMYIDENTITY_OPENIDCONNECT_OIDC_ENDPOINT,
                   APPLICATION_TITLE,
                   HOSTNAME_URL)

--- a/sharemyhealth/settings.py
+++ b/sharemyhealth/settings.py
@@ -249,11 +249,12 @@ DEFAULT_DISCLOSURE_TEXT = """
 
 DISCLOSURE_TEXT = env('DJANGO_PRIVACY_POLICY_URI', DEFAULT_DISCLOSURE_TEXT)
 
-HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
+HOSTNAME_URL = env('HOSTNAME_URL', 'http://sharemyhealth:8000')
 
-VMI_SIGNUP_URL = "%s/accounts/create-account/%s/" % \
+VMI_SIGNUP_URL = "%s/accounts/create-account/%s/?redirect_url=%s" % \
                  (SOCIAL_AUTH_VERIFYMYIDENTITY_OPENIDCONNECT_OIDC_ENDPOINT,
-                  APPLICATION_TITLE)
+                  APPLICATION_TITLE,
+                  HOSTNAME_URL)
 
 SETTINGS_EXPORT = [
     'DEBUG',


### PR DESCRIPTION
1/2 of the work to pass a query string including a `redirect_url`

NOTE: changed `HOSTNAME_URL` to be different.  This may have implications that are unintended other places.  This of course would not be necessary and the query string in `VMI_SIGNUP_URL` could be hardcoded.  