### PR TITLE
Revert settings dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,0 @@
-# set the username and passwords and save as .env
-HIE_TOKEN_API_URI=https://integration.hixny.com:6443
-HIE_PATIENT_API_URI=https://integration.hixny.com:5443
-HIE_WORKBENCH_USERNAME=theusername
-HIE_WORKBENCH_PASSWORD=thepassword
-HIE_BASIC_AUTH_PASSWORD=theotherpassword

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ py==1.6.0
 pycodestyle==2.3.1
 pyflakes==1.6.0
 python-coveralls==2.9.1
-python-dotenv==0.10.3
 pytz==2018.5
 PyYAML==4.2b1
 requests==2.20.0

--- a/sharemyhealth/settings.py
+++ b/sharemyhealth/settings.py
@@ -12,20 +12,15 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 
 import os
 import dj_database_url
-from dotenv import load_dotenv
 from django.contrib.messages import constants as messages
 from getenv import env
 from django.utils.translation import ugettext_lazy as _
-
-# load any .env file in the project root folder
-env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
-if os.path.exists(env_path):
-    load_dotenv(dotenv_path=env_path)
 
 os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/


### PR DESCRIPTION
don't use python-dotenv to load .env in settings in production. We can put this into a separate dev environment settings file instead.