### PR TITLE
Hixny don't connect conditions

### DIFF
--- a/apps/hie/models.py
+++ b/apps/hie/models.py
@@ -38,6 +38,11 @@ class HIEProfile(models.Model):
         return display
 
     @property
+    def flag_dont_connect(self):
+        boundary = '0' * 64  # a zero-filled string the max length of the mrn
+        return self.mrn <= boundary  # don't connect if mrn <= boundary
+
+    @property
     def consent_to_share_data(self):
         if self.user_accept is True:
             return 1


### PR DESCRIPTION
* Add flag_dont_connect to HIEProfile, which is if the MRN is less than or equal to '0'*64, which indicates that data should not be fetched from Hixny.
* Use the existing cda & fhir content if this flag is True
* Don't send consumer directive request if .mrn is ot set