### PR TITLE
Send hixny errors in lieu of patient data

### DIFF
--- a/apps/hie/api_views.py
+++ b/apps/hie/api_views.py
@@ -20,7 +20,10 @@ def get_patient_fhir_content(request):
     if not hie_data.get('error'):
         hp.__dict__.update(**hie_data)
         hp.save()
-    return JsonResponse(json.loads(hp.fhir_content or '{}'))
+    if hp.fhir_content:
+        return JsonResponse(json.loads(hp.fhir_content))
+    else:
+        return JsonResponse(hie_data)
 
 
 @require_GET


### PR DESCRIPTION
For the sake of debugging, include hixny response bodies in the data returned by hixny_requests.fetch_patient_data(), along with more informative error messaging