### PR TITLE
Limit hixny data calls

### DIFF
--- a/apps/hie/api_views.py
+++ b/apps/hie/api_views.py
@@ -1,12 +1,11 @@
 import sys
 import logging
-from datetime import timedelta
 import json
+import traceback
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse, FileResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET
-from django.utils import timezone
 from oauth2_provider.decorators import protected_resource
 from collections import OrderedDict
 from .models import HIEProfile
@@ -35,7 +34,7 @@ def get_patient_fhir_content(request):
             if not result.get('error'):
                 hp.__dict__.update(**result)
                 hp.save()
-        except:
+        except Exception:
             logger.error(
                 "Request to fetch_patient_data from Hixny failed for %r: %s"
                 % (up, sys.exc_info()[1])

--- a/apps/hie/api_views.py
+++ b/apps/hie/api_views.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
 import json
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse, FileResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET
+from django.utils import timezone
 from oauth2_provider.decorators import protected_resource
 from collections import OrderedDict
 from .models import HIEProfile
@@ -13,13 +15,31 @@ from . import hixny_requests
 @require_GET
 @protected_resource()
 def get_patient_fhir_content(request):
-    user = request.resource_owner
-    up, g_o_c = UserProfile.objects.get_or_create(user=user)
-    hp, g_o_c = HIEProfile.objects.get_or_create(user=user)
-    hie_data = hixny_requests.fetch_patient_data(user, hp, up)
-    if not hie_data.get('error'):
-        hp.__dict__.update(**hie_data)
-        hp.save()
+    """Only fetch the patient FHIR data from HIXNY if ALL of the following are true:
+
+    * the request.user is the resource owner, AND
+    * the data is empty or more than 24-hrs old, AND 
+    * user explicitly requests refresh.
+    """
+    owner = request.resource_owner
+    hp, g_o_c = HIEProfile.objects.get_or_create(user=owner)
+
+    if (
+        request.user == owner
+        and (
+            not hp.fhir_content
+            or (timezone.now() - hp.updated_at) > timedelta(hours=24)
+        )
+        and request.GET.get('refresh', None)
+    ):
+        up, g_o_c = UserProfile.objects.get_or_create(user=owner)
+        hie_data = hixny_requests.fetch_patient_data(owner, hp, up)
+        if not hie_data.get('error'):
+            hp.__dict__.update(**hie_data)
+            hp.save()
+    elif not hp.fhir_content:
+        hie_data = {'error': "FHIR content is not available"}
+
     if hp.fhir_content:
         return JsonResponse(json.loads(hp.fhir_content))
     else:

--- a/sharemyhealth/signals.py
+++ b/sharemyhealth/signals.py
@@ -1,17 +1,36 @@
+import traceback
+import logging
 from oauth2_provider.signals import app_authorized
 from django.contrib.auth import get_user_model
+from apps.hie import hixny_requests
 from apps.hie.models import HIEProfile
+from apps.accounts.models import UserProfile
+
+logger = logging.getLogger(__name__)
 
 
 def handle_app_authorized(sender, request, token, **kwargs):
-    """This app is now authorized to connect to Hixny data (per the authorize.html form),
-    so let's save that fact.
+    """This app is now authorized to connect to Hixny data (per the authorize.html 
+    form), so let's save that fact and get the data.
     """
     User = get_user_model()
     user = User.objects.get(id=token.user_id)
     hie_profile, created = HIEProfile.objects.get_or_create(user=user)
     hie_profile.user_accept = True
     hie_profile.save()
+
+    # let's try getting the user's data now
+    user_profile, _ = UserProfile.objects.get_or_create(user=user)
+    try:
+        result = hixny_requests.fetch_patient_data(user, hie_profile, user_profile)
+        if not result.get('error'):
+            hie_profile.__dict__.update(**result)
+            hie_profile.save()
+    except:
+        logger.error(
+            "Request to fetch_patient_data from Hixny failed for %r\n%s"
+            % (user_profile, traceback.format_exc())
+        )
 
 
 app_authorized.connect(handle_app_authorized)

--- a/sharemyhealth/signals.py
+++ b/sharemyhealth/signals.py
@@ -26,7 +26,7 @@ def handle_app_authorized(sender, request, token, **kwargs):
         if not result.get('error'):
             hie_profile.__dict__.update(**result)
             hie_profile.save()
-    except:
+    except Exception:
         logger.error(
             "Request to fetch_patient_data from Hixny failed for %r\n%s"
             % (user_profile, traceback.format_exc())


### PR DESCRIPTION
Only refresh health data from hixny if the client requests it.
Try to get the data from hixny immediate after the member approves doing so.